### PR TITLE
Update to Fuel 1.2.1 that compiles with jitpack.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ bintray {
 }
 
 dependencies {
-  compile 'com.github.kittinunf.fuel:fuel:1.2.0'
+  compile 'com.github.kittinunf.fuel:fuel:1.2.1'
   compile 'com.github.salomonbrys.kotson:kotson:2.1.0'
   compile 'org.slf4j:slf4j-api:1.7.19'
   compile 'org.slf4j:slf4j-log4j12:1.7.19'


### PR DESCRIPTION
Since the artifacts are not published on maven, other developers like me may want to get it from jitpack.io.

Unfortunately Fuel:1.2.0 doesn't compile on jitpack resulting of a failed dependency.

This PR should solve the issue while remaining compatible.
